### PR TITLE
chore: DATA-11172 Populate data tags despite of data_tag_enabled setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Draft
+### Changed
+- Populate data tags despite of data_tag_enabled setting [#2](https://github.com/bigcommerce/themes-lib-skeleton/pull/2)
+
 ### [3.0.0] - 2021-05-028
 ## Added
 - Missing Core files

--- a/templates/components/common/banner.html
+++ b/templates/components/common/banner.html
@@ -10,36 +10,22 @@
   "
   data-banner
 >
-  {{#if settings.data_tag_enabled}}
-    {{#each (limit banner 1)}}
-      <div
-        class="banner-content"
-        data-event-type="promotion"
-        data-entity-id="{{this.id}}"
-        data-name="{{this.banner-name}}"
-        data-position="{{this.location}}"
-        data-name="{{this.banner-name}}"
-      >
-        <div data-event-type="promotion-click">
-          {{{this.content}}}
-        </div>
-    </div>
-    {{#if dismissable}}
-      <button class="btn-banner-dismiss" data-banner-dismiss>
-        {{> components/icons/close}}
-      </button>
-    {{/if}}
-    {{/each}}
-  {{else}}
-    {{#each (limit banner 1)}}
-      <div class="banner-content">
+  {{#each (limit banner 1)}}
+    <div
+      class="banner-content"
+      data-event-type="promotion"
+      data-entity-id="{{this.id}}"
+      data-name="{{this.banner-name}}"
+      data-position="{{this.location}}"
+    >
+      <div data-event-type="promotion-click">
         {{{this.content}}}
       </div>
-      {{#if dismissable}}
-        <button class="btn-banner-dismiss" data-banner-dismiss>
-          {{> components/icons/close}}
-        </button>
-      {{/if}}
-    {{/each}}
+  </div>
+  {{#if dismissable}}
+    <button class="btn-banner-dismiss" data-banner-dismiss>
+      {{> components/icons/close}}
+    </button>
   {{/if}}
+  {{/each}}
 </section>

--- a/templates/components/compare/compare-grid.html
+++ b/templates/components/compare/compare-grid.html
@@ -76,9 +76,7 @@
                 <a
                   href="{{url}}"
                   class="button button-primary button-progress"
-                  {{#if ../../../../../settings.data_tag_enabled}}
-                    data-event-type="product-click"
-                  {{/if}}
+                  data-event-type="product-click"
                 >
                   {{lang 'product.pre_order'}}
                 </a>
@@ -86,9 +84,7 @@
                 <a
                   href="{{add_to_cart_url}}"
                   class="button button-primary button-progress"
-                  {{#if ../../../../../settings.data_tag_enabled}}
-                    data-event-type="product-click"
-                  {{/if}}
+                  data-event-type="product-click"
                 >
                   {{lang 'product.add_to_cart'}}
                 </a>

--- a/templates/components/home/grid.html
+++ b/templates/components/home/grid.html
@@ -7,16 +7,14 @@
 
 <div
   class="product-listing product-{{number}}"
-  {{#if settings.data_tag_enabled}}
-    {{#if data '===' 'featured'}}
-      data-list-name="{{lang 'data_tags.featured'}}"
-    {{/if}}
-    {{#if data '===' 'new'}}
-      data-list-name="{{lang 'data_tags.new'}}"
-    {{/if}}
-    {{#if data '===' 'top-sellers'}}
-      data-list-name="{{lang 'data_tags.popular'}}"
-    {{/if}}
+  {{#if data '===' 'featured'}}
+    data-list-name="{{lang 'data_tags.featured'}}"
+  {{/if}}
+  {{#if data '===' 'new'}}
+    data-list-name="{{lang 'data_tags.new'}}"
+  {{/if}}
+  {{#if data '===' 'top-sellers'}}
+    data-list-name="{{lang 'data_tags.popular'}}"
   {{/if}}
 >
   {{#each (limit items limit)}}
@@ -33,7 +31,6 @@
       sale_price_label=../theme_settings.sale-price-label
       price_label=../theme_settings.price-label
       sale_badges=../theme_settings.sale-badges
-      data_tag_enabled=../settings.data_tag_enabled
       event="list"
       position=(add @index 1)
     }}

--- a/templates/components/product-catalog/grid.html
+++ b/templates/components/product-catalog/grid.html
@@ -32,7 +32,6 @@
             sale_price_label=../theme_settings.sale-price-label
             price_label=../theme_settings.price-label
             sale_badges=../theme_settings.sale-badges
-            data_tag_enabled=../settings.data_tag_enabled
             event="list"
             position=(add @index 1)
           }}

--- a/templates/components/product-catalog/product-item.html
+++ b/templates/components/product-catalog/product-item.html
@@ -10,15 +10,13 @@
         product-item-image-noimage
       {{/unless}}
     "
-    {{#if data_tag_enabled}}
-      data-event-type="{{event}}"
-      data-entity-id="{{id}}"
-      data-position="{{position}}"
-      data-name="{{name}}"
-      data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-      data-product-brand="{{brand.name}}"
-      data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
-    {{/if}}
+    data-event-type="{{event}}"
+    data-entity-id="{{id}}"
+    data-position="{{position}}"
+    data-name="{{name}}"
+    data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+    data-product-brand="{{brand.name}}"
+    data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
   >
     <a href="{{url}}">
       {{> components/common/responsive-image

--- a/templates/components/product/layout/form-actions.html
+++ b/templates/components/product/layout/form-actions.html
@@ -18,9 +18,7 @@
         type="submit"
         data-button-purchase
         data-product-title="{{product.title}}"
-        {{#if settings.data_tag_enabled}}
-          data-event-type="product-click"
-        {{/if}}
+        data-event-type="product-click"
       >
         {{#if product.pre_order}}
           <span class="button-text">{{lang 'product.pre_order'}}</span>
@@ -36,9 +34,7 @@
         {{#if product.out_of_stock}}
           <div
             class="button button-disabled"
-            {{#if settings.data_tag_enabled}}
-              data-event-type="product-click"
-            {{/if}}
+            data-event-type="product-click"
           >
             {{lang 'product.sold_out'}}
           </div>

--- a/templates/core/amp/category/product-item.html
+++ b/templates/core/amp/category/product-item.html
@@ -1,14 +1,12 @@
 <article
   class="amp-grid-item amp-product-grid-item"
-  {{#if data_tag_enabled}}
-    data-event-type="product"
-    data-entity-id="{{id}}"
-    data-name="{{title}}"
-    data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-    data-product-brand="{{brand.name}}"
-    data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
-    data-product-variant="single-product-option"
-  {{/if}}
+  data-event-type="product"
+  data-entity-id="{{id}}"
+  data-name="{{title}}"
+  data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+  data-product-brand="{{brand.name}}"
+  data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
+  data-product-variant="single-product-option"
 >
   {{#if price.saved}}
     {{#unless out_of_stock_message}}

--- a/templates/core/amp/category/product-listing.html
+++ b/templates/core/amp/category/product-listing.html
@@ -11,7 +11,6 @@
         non_sale_price_label=../theme_settings.non-sale-price-label
         sale_price_label=../theme_settings.sale-price-label
         price_label=../theme_settings.price-label
-        data_tag_enabled=../settings.data_tag_enabled
         event="list"
         position=(add @index 1)
       }}

--- a/templates/core/amp/products/product-details.html
+++ b/templates/core/amp/products/product-details.html
@@ -1,14 +1,12 @@
 <section
   class="amp-product-details"
-  {{#if settings.data_tag_enabled}}
-    data-event-type="product"
-    data-entity-id="{{product.id}}"
-    data-name="{{product.title}}"
-    data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-    data-product-brand="{{product.brand.name}}"
-    data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
-    data-product-variant="single-product-option"
-  {{/if}}
+  data-event-type="product"
+  data-entity-id="{{product.id}}"
+  data-name="{{product.title}}"
+  data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+  data-product-brand="{{product.brand.name}}"
+  data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
+  data-product-variant="single-product-option"
 >
   {{#if product.price.saved}}
     <div class="product-badge product-badge-sale">

--- a/templates/core/amp/products/product-form.html
+++ b/templates/core/amp/products/product-form.html
@@ -16,9 +16,7 @@
     <a
       class="button amp-button-primary"
       href="{{product.cart_url}}"
-      {{#if settings.data_tag_enabled}}
-        data-event-type="product-click"
-      {{/if}}
+      data-event-type="product-click"
     >
       {{#if product.pre_order}}
         <span class="button-text">

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -17,9 +17,7 @@ brand:
     data-facet-content
     data-pagination-content
     data-pagination-id="0"
-    {{#if settings.data_tag_enabled}}
-      data-list-name="{{lang 'data_tags.brand' name=brand.name}}"
-    {{/if}}
+    data-list-name="{{lang 'data_tags.brand' name=brand.name}}"
   >
 
     {{> components/product-catalog/catalog-index}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -17,9 +17,7 @@ category:
     data-facet-content
     data-pagination-content
     data-pagination-id="0"
-    {{#if settings.data_tag_enabled}}
-      data-list-name="{{lang 'data_tags.category' name=category.name}}"
-    {{/if}}
+    data-list-name="{{lang 'data_tags.category' name=category.name}}"
   >
 
     {{> components/product-catalog/catalog-index}}

--- a/templates/pages/custom/product/alternate-product.html
+++ b/templates/pages/custom/product/alternate-product.html
@@ -40,7 +40,6 @@ product:
             sale_price_label=../theme_settings.sale-price-label
             price_label=../theme_settings.price-label
             sale_badges=../theme_settings.sale-badges
-            data_tag_enabled=../settings.data_tag_enabled
             event="list"
             position=(add @index 1)
           }}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -15,15 +15,13 @@ product:
       class="product-details-wrapper"
       data-product-details
       data-product-title="{{product.title}}"
-      {{#if settings.data_tag_enabled}}
-        data-event-type="product"
-        data-entity-id="{{product.id}}"
-        data-name="{{product.title}}"
-        data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-        data-product-brand="{{product.brand.name}}"
-        data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
-        data-product-variant="single-product-option"
-      {{/if}}
+      data-event-type="product"
+      data-entity-id="{{product.id}}"
+      data-name="{{product.title}}"
+      data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+      data-product-brand="{{product.brand.name}}"
+      data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
+      data-product-variant="single-product-option"
     >
 
       {{> components/product/details-compact}}
@@ -51,7 +49,6 @@ product:
             sale_price_label=../theme_settings.sale-price-label
             price_label=../theme_settings.price-label
             sale_badges=../theme_settings.sale-badges
-            data_tag_enabled=../settings.data_tag_enabled
             event="list"
             position=(add @index 1)
           }}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -68,9 +68,7 @@ product_results:
       data-pagination-id="0"
       data-tab="0"
       data-tab-group="0"
-      {{#if settings.data_tag_enabled}}
-        data-list-name="{{lang 'data_tags.search'}}"
-      {{/if}}
+      data-list-name="{{lang 'data_tags.search'}}"
     >
 
       {{> components/product-catalog/catalog-index}}


### PR DESCRIPTION
## What? [DATA-11172](https://bigcommercecloud.atlassian.net/browse/DATA-11172)
Previously we populated data tags only when Universal Google Analytics was enabled. Since it's now going away there will be no way for merchants to enable these data tags on their stores. As some merchants were using them to build their custom analytics integrations, it has been decided to populate data tags for all merchants despite of `data-tag_enable` setting, so that they can proceed using it even when Universal Google Analytics is gone.

## Tickets / Documentation

Add links to any relevant tickets and documentation.
- Jira ticket [DATA-11172](https://bigcommercecloud.atlassian.net/browse/DATA-11172)
- [Original github issue](https://github.com/bigcommerce/cornerstone/issues/2195)


[DATA-11172]: https://bigcommercecloud.atlassian.net/browse/DATA-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-11172]: https://bigcommercecloud.atlassian.net/browse/DATA-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ